### PR TITLE
Save progress button 

### DIFF
--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   stepper: {
-    padding: theme.spacing(3, 0, 5),
+    padding: theme.spacing(5, 0, 5),
   },
   buttons: {
     display: 'flex',
@@ -148,6 +148,8 @@ const Form = () => {
                       Back
                     </Button>
                   )}
+
+                <Button className={classes.button}>{"Save Progress"}</Button>
                   <Button
                     disabled={loading}
                     variant="contained"

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -149,7 +149,10 @@ const Form = () => {
                     </Button>
                   )}
 
-                <Button className={classes.button}>{"Save Progress"}</Button>
+                <Button onClick={() => console.log("Progress being saved")} className={classes.button}>
+                  {"Save Progress"}
+                </Button>
+
                   <Button
                     disabled={loading}
                     variant="contained"

--- a/client/src/components/Form.js
+++ b/client/src/components/Form.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   stepper: {
-    padding: theme.spacing(5, 0, 5),
+    padding: theme.spacing(3, 0, 5),
   },
   buttons: {
     display: 'flex',


### PR DESCRIPTION
### What this PR does:

- creates a save progress button for those entering FSC data
- closes issue #10 for save later button


<img width="307" alt="Screen Shot 2020-08-01 at 5 10 41 PM" src="https://user-images.githubusercontent.com/30880055/89112614-30baad00-d41a-11ea-9834-8a8c842ea37d.png">
<img width="357" alt="Screen Shot 2020-08-01 at 5 10 47 PM" src="https://user-images.githubusercontent.com/30880055/89112615-32847080-d41a-11ea-83ef-0abfa1578806.png">
<img width="412" alt="Screen Shot 2020-08-01 at 5 10 51 PM" src="https://user-images.githubusercontent.com/30880055/89112616-344e3400-d41a-11ea-9abc-9ed3b45f9147.png">
